### PR TITLE
Adjust docs for new Sphinx Symbiflow Theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-sphinx_materialdesign_theme
+Sphinx
+git+http://github.com/SymbiFlow/sphinx_materialdesign_theme.git@master#egg=sphinx_symbiflow_theme
 sphinx-markdown-tables

--- a/source/conf.py
+++ b/source/conf.py
@@ -92,7 +92,7 @@ pygments_style = 'default'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = "sphinx_materialdesign_theme"
+html_theme = "sphinx_symbiflow_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This PR replaces the original sphinx_materialdesing_theme with our fork of it which includes few 
modifications:
- The name changed to the "sphinx_symbiflow_theme"
- Wider margins in tables and images
- Images' and Tables' max size changed to 90%
- A lowered title header and right sidebar
- A bigger font
- Images and Tables centered by default
- A links' color changed to purple
- CSS Classes for centering/default alignment
- Added Makefile for more intuitive building process