### PR TITLE
Generate symbols for all sim.v models

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,9 @@ channels:
 dependencies:
   - doxygen
   - cmake
+  - pygobject
+  - cairo
+  - pango
   - pip
   - pip:
     - -r file:requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==2.0.0
 git+http://github.com/SymbiFlow/sphinx_materialdesign_theme.git@master#egg=sphinx_symbiflow_theme
 sphinx-markdown-tables
 breathe==4.13.1
+symbolator==1.0.2

--- a/source/conf.py
+++ b/source/conf.py
@@ -25,7 +25,8 @@ needs_sphinx = '1.6'
 extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.imgmath',  # breathe
-    'breathe'
+    'breathe',
+    'symbolator_sphinx',
 ]
 
 numfig = True
@@ -318,4 +319,8 @@ breathe_projects = {
     "prjxray" : "../build/doxygen/prjxray/xml",
 }
 
+### SYMBOLATOR ###
+
+symbolator_cmd_args       = ['--transparent']
+symbolator_output_format  = 'svg'
 


### PR DESCRIPTION
This PR depends on #57 because it uses conda and should be merged after #57.
This PR adds the Symbolator to the Symbiflow Documentation.

The plugin allows generating model diagrams of Verilog files.
It can be used to obtain diagrams of sim.v files from the Symbiflow Architecture Definitions. 
In order to insert the symbols in Sphinx you need to add the follwing RST directive to you file:
<pre>
.. symbolator:: path/to/verilog/file.v
</pre>

