### PR TITLE
Check out submodules recursively

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -18,3 +18,7 @@ python:
 
 conda:
   environment: environment.yml
+
+submodules:
+  include: all
+  recursive: true


### PR DESCRIPTION
This PR make RTD checkout the submodules recursively. 
Without it we are missing several chapters of the doc. 