### PR TITLE
Add missing extensions and exclude patterns to reduce warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 Sphinx==2.4.0
 git+http://github.com/SymbiFlow/sphinx_materialdesign_theme.git@master#egg=sphinx_symbiflow_theme
-sphinx-markdown-tables
+sphinx-markdown-tables==0.0.12
 breathe==4.13.1
 symbolator==1.0.2
 sphinxcontrib-images==0.9.1
+recommonmark==0.6.0
+sphinxcontrib-bibtex==0.4.2
+sphinxcontrib-domaintools==0.2

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,14 +20,23 @@ import sys, os
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = '1.6'
 
+# For VTR documentation support
+sys.path.append(os.path.abspath('./vtr-verilog-to-routing/doc/_exts'))
+
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.todo',
+    'sphinx.ext.autodoc',
     'sphinx.ext.imgmath',  # breathe
     'breathe',
     'symbolator_sphinx',
-    'sphinxcontrib.images'
+    'sphinxcontrib.images',
+    'sphinxcontrib.bibtex',
+    'sdcdomain',
+    'archdomain',
+    'rrgraphdomain',
+    'recommonmark'
 ]
 
 numfig = True
@@ -36,7 +45,7 @@ numfig = True
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
@@ -71,7 +80,16 @@ today_fmt = '%Y-%m-%d'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = [
+    'symbiflow-arch-defs/*',
+    'symbiflow-arch-defs/third_party/**',
+    'prjtrellis/third_party/**',
+    'prjxray/third_party/**',
+    'prjxray/docs/db_dev_process/fuzzers/index/**',
+    'prjxray/docs/db_dev_process/minitests/index/**',
+    'vtr-verilog-to-routing/libs/EXTERNAL/**.md',
+    'vtr-verilog-to-routing/.github/**',
+]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None


### PR DESCRIPTION
This commits add missing sphinx extensions used by the VTR project, and other missing dependencies which reduce the number of warnings. Additional exclude patterns disable searching for source files in undesirable directories. This PR is related to #5.

Resolves #147 