### PR TITLE
Fix documentation building

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Sphinx==2.4.0
 git+http://github.com/SymbiFlow/sphinx_materialdesign_theme.git@master#egg=sphinx_symbiflow_theme
 sphinx-markdown-tables==0.0.12
-breathe==4.13.1
+breathe==4.18.1
 symbolator==1.0.2
-sphinxcontrib-images==0.9.1
+sphinxcontrib-images==0.9.2
 recommonmark==0.6.0
 sphinxcontrib-bibtex==0.4.2
-sphinxcontrib-domaintools==0.2
+sphinxcontrib-domaintools==0.3


### PR DESCRIPTION
This commit updates the python packages versions and excludes plugins which cause that SymbiFlow documentation build is failing in RTD.

https://readthedocs.org/projects/symbiflow/builds/