### PR TITLE
Fix missing symbiflow-arch-defs documentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==2.4.0
+Sphinx==3.0.4
 git+http://github.com/SymbiFlow/sphinx_materialdesign_theme.git@master#egg=sphinx_symbiflow_theme
 sphinx-markdown-tables==0.0.12
 breathe==4.18.1

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,7 +18,7 @@ import sys, os
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.6'
+needs_sphinx = '3.0.4'
 
 # For VTR documentation support
 sys.path.append(os.path.abspath('./vtr-verilog-to-routing/doc/_exts'))
@@ -81,7 +81,6 @@ today_fmt = '%Y-%m-%d'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = [
-    'symbiflow-arch-defs/*',
     'symbiflow-arch-defs/third_party/**',
     'prjtrellis/third_party/**',
     'prjxray/third_party/**',


### PR DESCRIPTION
This commit adds missing `symbiflow-arch-defs` documentation.
It also bumps the required Sphinx version to ensure the same build on RTD and locally.

Resolves https://github.com/SymbiFlow/symbiflow-docs/issues/288