### PR TITLE
fix env setup

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - pango
   - pip
   - pip:
-    - -r file:requirements.txt
+    - -r requirements.txt


### PR DESCRIPTION
This PR fixes broken conda environment setup. This bug caused all dependabot builds to fail (e.g. https://readthedocs.org/projects/symbiflow/builds/14358207/). The problem was previously discussed and solved in: https://github.com/SymbiFlow/symbiflow-examples/issues/169 but it seems that it is a common issue for multiple repositories.


Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>